### PR TITLE
Drop default_app_config for Django 3.2+

### DIFF
--- a/checkadmin/__init__.py
+++ b/checkadmin/__init__.py
@@ -1,3 +1,5 @@
+import django
+
 ignored = set()
 
 
@@ -5,4 +7,5 @@ def ignore(model):
     ignored.add(model)
 
 
-default_app_config = "checkadmin.apps.CheckAdminConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "checkadmin.apps.CheckAdminConfig"


### PR DESCRIPTION
Variable is deprecated from Django 3.2 onwards. Avoids deprecation
warnings in projects running Django 3.2+.