### PR TITLE
Update to support newer Django & Python, drop old versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,34 +15,30 @@ jobs:
         include:
           - python: 3.x
             toxenv: lint
-          - python: 3.6
-            toxenv: py36-django22
-          - python: 3.7
-            toxenv: py37-django22
-          - python: 3.8
-            toxenv: py38-django22
-          - python: 3.9
-            toxenv: py39-django22
-          - python: 3.6
-            toxenv: py36-django31
-          - python: 3.7
-            toxenv: py37-django31
-          - python: 3.8
-            toxenv: py38-django31
-          - python: 3.9
-            toxenv: py39-django31
-          - python: 3.6
-            toxenv: py36-django32
           - python: 3.7
             toxenv: py37-django32
           - python: 3.8
             toxenv: py38-django32
           - python: 3.9
             toxenv: py39-django32
+          - python: "3.10"
+            toxenv: py310-django32
           - python: 3.8
-            toxenv: py38-djangomain
+            toxenv: py38-django40
+          - python: 3.9
+            toxenv: py39-django40
+          - python: "3.10"
+            toxenv: py310-django40
+          - python: 3.8
+            toxenv: py38-django41
+          - python: 3.9
+            toxenv: py39-django41
+          - python: "3.10"
+            toxenv: py310-django41
           - python: 3.9
             toxenv: py39-djangomain
+          - python: "3.10"
+            toxenv: py310-djangomain
 
     steps:
       - uses: actions/checkout@v2

--- a/checkadmin/__init__.py
+++ b/checkadmin/__init__.py
@@ -1,6 +1,5 @@
 from typing import Set
 
-import django
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.db import models
@@ -18,7 +17,3 @@ def get_ignored() -> Set[models.Model]:
         model = django_apps.get_model(*model_path.rsplit(".", 1), False)
         ignored.add(model)
     return ignored
-
-
-if django.VERSION < (3, 2):
-    default_app_config = "checkadmin.apps.CheckAdminConfig"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,24 +11,24 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
-    Django >= 2.2
+    Django >= 3.2
 packages =
     checkadmin
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,39}-django22
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
-    py{38,39}-djangomain
+    py{37,38,39,310}-django32
+    py{38,39,310}-django40
+    py{38,39,310}-django41
+    py{39,310}-djangomain
 
 [testenv]
 deps =
-    django22: Django>=2.2,<2.3
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
 commands = python -m django test --settings tests.settings
 


### PR DESCRIPTION
Python 3.6 has reached its end of life.
Django version under 3.2 are no longer supported.